### PR TITLE
Update hosts.js - fix host when listing on ip

### DIFF
--- a/models/host.js
+++ b/models/host.js
@@ -12,6 +12,7 @@ module.exports = function(hosts, protocol, location){
 		var port     = request.headers.host.split(':')[1];
 		var hostname = isset(port) ? request.headers.host : request.headers.host+':'+80 ;
 		var app = hosts[hostname]                                   // find host
+		if (!(app && app.routes && app.routes[method])) var app = hosts['localhost:80']; // defaults to local
 		if(app && app.routes && app.routes[method]){                // check if host exists
 			var routes = app.routes[method]                         // method routes
 			var path = routes[location.pathname]                    // static path


### PR DESCRIPTION
When diet server listens on for example 80 and gets a request for a domain.tld thats not explicit listned on it fails with 404 host not found
This fixes this behavier by trying to defaulting to simply localhost:80 because thats the value diet.js binds too.

This way we examin if we got a per hostname config via server listen if not we dauflt to localhost:80 if that has no listen then we simply fail.

Note:
we could upgrade this patch to access first host or last hosts element if needed because issus with localhost:80